### PR TITLE
Typo & new name for package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This preset configures [remark-lint](https://github.com/wooorm/remark-lint) with
 | [`maximum-heading-length`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-maximum-heading-length)                       | `['off']`                    |
 | [`maximum-line-length`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-maximum-line-length)                             | `['off']`                    |
 | [`no-auto-link-without-protocol`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-auto-link-without-protocol)         | `['error']`                  |
-| [`no-blockquote-without-caret`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-blockquote-without-caret)             | `['error']`                  |
+| [`no-blockquote-without-marker`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-blockquote-without-marker)             | `['error']`                  |
 | [`no-consecutive-blank-lines`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-consecutive-blank-lines)               | `['error']`                  |
 | [`no-duplicate-definitions`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-duplicate-definitions)                   | `['error']`                  |
 | [`no-duplicate-headings`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-duplicate-headings)                         | `['off']`                    |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This preset configures [remark-lint](https://github.com/wooorm/remark-lint) with
 | [`definition-spacing`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-definition-spacing)                               | `['error']`                  |
 | [`emphasis-marker`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-emphasis-marker)                                     | `['error', '_']`             |
 | [`fenced-code-flag`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-fenced-code-flag)                                   | `['error']`                  |
-| [`fenced-code-marker`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-fenced-code-marker)                               | ``['error', '`'`]`           |
+| [`fenced-code-marker`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-fenced-code-marker)                               | ``['error', '`']``           |
 | [`file-extension`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-file-extension)                                       | `['error']`                  |
 | [`final-definition`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-final-definition)                                   | `['error']`                  |
 | [`final-newline`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-final-newline)                                         | `['off']`                    |

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var plugins = [
 	// [require('remark-lint-maximum-heading-length'), ['off']],
 	// [require('remark-lint-maximum-line-length', ['off']],
 	[require('remark-lint-no-auto-link-without-protocol'), ['error']],
-	[require('remark-lint-no-blockquote-without-caret'), ['error']],
+	[require('remark-lint-no-blockquote-without-marker'), ['error']],
 	[require('remark-lint-no-consecutive-blank-lines'), ['error']],
 	[require('remark-lint-no-duplicate-definitions'), ['error']],
 	// [require('remark-lint-no-duplicate-headings'), ['off']],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "remark-lint-list-item-content-indent": "^1.0.0",
     "remark-lint-list-item-indent": "^1.0.0",
     "remark-lint-no-auto-link-without-protocol": "^1.0.0",
-    "remark-lint-no-blockquote-without-caret": "^1.0.0",
+    "remark-lint-no-blockquote-without-marker": "^2.0.0",
     "remark-lint-no-consecutive-blank-lines": "^1.0.0",
     "remark-lint-no-duplicate-definitions": "^1.0.0",
     "remark-lint-no-duplicate-headings-in-section": "^1.0.0",


### PR DESCRIPTION
👋

Thanks for using remark!
* I saw a typo in the readme, and fixed it
* `no-blockquote-without-caret` is now called `no-blockquote-without-marker` as it was confusingly named.